### PR TITLE
fix: 修复聊天第11分页未应用聊天助手

### DIFF
--- a/Boilerplate_!Base/src/lib/Constant.lua
+++ b/Boilerplate_!Base/src/lib/Constant.lua
@@ -459,6 +459,7 @@ local CONSTANT = {
 		8,
 		9,
 		10,
+		11,
 		'_Recently',
 	}),
 	ITEM_QUALITY = X.FreezeTable({


### PR DESCRIPTION
大佬好，我发现第11聊天分页未应用聊天助手，界面名为 "ChatPanel_Normal11"，故修复之。